### PR TITLE
Enable installation via Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   ],
   "ignore": [
     "**/.*",
-    "Makefile"
+    "Makefile",
     "test",
     "package.json",
     "lib"


### PR DESCRIPTION
Hi there and thanks for an awesome logging library :)

I just registered minilog-bower via Bower to enable a convenient clientside installation of the library when used in the browser. Maybe you would like to integrate it in your project? If so, I will happily request  the unregistration of the  `minilog-bower` package and use your version directly.
