### PR TITLE
Added ability to send extra information

### DIFF
--- a/lib/web/jquery_simple.js
+++ b/lib/web/jquery_simple.js
@@ -1,5 +1,7 @@
 var Transform = require('../common/transform.js');
 
+var cid = new Date().valueOf().toString(36);
+
 function AjaxLogger(options) {
   this.url = options.url || '';
   this.cache = [];
@@ -21,7 +23,7 @@ AjaxLogger.prototype.init = function() {
   if(!this.enabled || !this.jQuery) return;
   var self = this;
   this.timer = setTimeout(function() {
-    var i, logs = [], ajaxData;
+    var i, logs = [], ajaxData, url = self.url;
     if(self.cache.length == 0) return self.init();
     // Need to convert each log line individually
     // so that having invalid (circular) references won't impact all the lines.
@@ -31,13 +33,14 @@ AjaxLogger.prototype.init = function() {
         logs.push(JSON.stringify(self.cache[i]));
       } catch(e) { }
     }
-    if(!self.jQuery.isEmptyObject(self.extras)) {
-        ajaxData = JSON.stringify(self.jQuery.extend({logs: logs}, self.extras));
-    } else {
+    if(self.jQuery.isEmptyObject(self.extras)) {
         ajaxData = logs.join('\n');
+        url = self.url + '?client_id=' + cid;
+    } else {
+        ajaxData = JSON.stringify(self.jQuery.extend({logs: logs}, self.extras));
     }
 
-    self.jQuery.ajax(self.url, {
+    self.jQuery.ajax(url, {
       type: 'POST',
       cache: false,
       processData: false,


### PR DESCRIPTION
- If the instance has `extras` assigned send object instead and
  `logs` as a property.
- ~~remove cid query string as this should be done through `extras`~~
- Keep cid query string _only_ when no `extras` are provided. 

I think cid format should be up to the user and with this PR they can do:

``` js
var logger = new Minilog.backends.jQuery();
logger.extras.cid = 1234567;
```

That will post:

``` js
{
   cid: 1234567,
   logs: [...]
}
```

If no extras are specified it will POST in the same format as it does now.

mixu/minilog#17
