### PR TITLE
Change stack formatting in npm

### DIFF
--- a/lib/node/formatters/withstack.js
+++ b/lib/node/formatters/withstack.js
@@ -5,6 +5,22 @@ function FormatNpm() {}
 
 Transform.mixin(FormatNpm);
 
+function noop(a){
+  return a;
+}
+
+var types = {
+  string: noop,
+  number: noop,
+  default: JSON.stringify.bind(JSON)
+};
+
+function stringify(args) {
+  return args.map(function(arg) {
+    return (types[typeof arg] || types.default)(arg);
+  });
+}
+
 FormatNpm.prototype.write = function(name, level, args) {
   var colors = { debug: 'magenta', info: 'cyan', warn: 'yellow', error: 'red' };
   function pad(s) { return (s.toString().length == 4? ' '+s : s); }
@@ -20,17 +36,17 @@ FormatNpm.prototype.write = function(name, level, args) {
     return stack;
   }
 
-  var frame = getStack()[4];
+  var frame = getStack()[5],
+      fileName = FormatNpm.fullPath ? frame.getFileName() : frame.getFileName().replace(/^.*\/(.+)$/, '/$1');
 
   this.emit('item', (name ? name + ' ' : '')
           + (level ? style(pad(level), colors[level]) + ' ' : '')
-          + style(
-              frame.getFileName().replace(new RegExp('^.*/(.+)$'), '/$1')
-              + ":" + frame.getLineNumber()
-            , 'grey')
+          + style(fileName + ":" + frame.getLineNumber(), 'grey')
           + ' '
-          + args.join(' '));
+          + stringify(args).join(' '));
 };
+
+FormatNpm.fullPath = true;
 
 module.exports = FormatNpm;
 


### PR DESCRIPTION
- Adds saner stringify for objects
- Allows full path printing for file name and defaults to on

/cc @vanchi-zendesk @mixu
