### PR TITLE
Replaced semicolon with comma which was prematurely ending var declarations

### DIFF
--- a/lib/web/formatters/minilog.js
+++ b/lib/web/formatters/minilog.js
@@ -1,5 +1,5 @@
 var Transform = require('../../common/transform.js'),
-    color = require('./util.js');
+    color = require('./util.js'),
     colors = { debug: ['gray'], info: ['purple' ], warn: [ 'yellow', true ], error: [ 'red', true ] },
     logger = new Transform();
 


### PR DESCRIPTION
This was causing an error when `require()`ing the library via Browserify.