### PR TITLE
Use the Chrome formatter when running in Electron

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,12 @@ module.exports = require('./common/minilog.js');
 
 var consoleLogger = require('./node/console.js');
 
+// if we are running inside Electron then use the web version of console.js
+isChrome = (typeof navigator != 'undefined' && /chrome/i.test(navigator.userAgent));
+if (isChrome) {
+    consoleLogger = require('./web/console.js').minilog;
+}
+
 // intercept the pipe method and transparently wrap the stringifier, if the
 // destination is a Node core stream
 


### PR DESCRIPTION
When using minilog in Electron, use the Chrome formatter instead of the Node formatter.