### PR TITLE
Added time.js formatter.

### DIFF
--- a/lib/node/console.js
+++ b/lib/node/console.js
@@ -20,7 +20,7 @@ e.filterEnv = function() {
 
 e.formatters = [
     'formatClean', 'formatColor', 'formatNpm',
-    'formatLearnboost', 'formatMinilog', 'formatWithStack'
+    'formatLearnboost', 'formatMinilog', 'formatWithStack', 'formatTime'
 ];
 
 e.formatClean = new (require('./formatters/clean.js'));
@@ -29,5 +29,6 @@ e.formatNpm = new (require('./formatters/npm.js'));
 e.formatLearnboost = new (require('./formatters/learnboost.js'));
 e.formatMinilog = new (require('./formatters/minilog.js'));
 e.formatWithStack = new (require('./formatters/withstack.js'));
+e.formatTime = new (require('./formatters/time.js'));
 
 module.exports = e;

--- a/lib/node/formatters/time.js
+++ b/lib/node/formatters/time.js
@@ -1,0 +1,30 @@
+var Transform = require('../../common/transform.js'),
+    style = require('./util.js').style,
+    util = require('util');
+
+function FormatTime() {}
+
+function timestamp() {
+  var d = new Date();
+  return ("0" + d.getDate()).slice(-2) + "-" + 
+  ("0"+(d.getMonth()+1)).slice(-2) + "-" +
+  d.getFullYear() + " " + 
+  ("0" + d.getHours()).slice(-2) + ":" + 
+  ("0" + d.getMinutes()).slice(-2) + ":" + 
+  ("0" + d.getSeconds()).slice(-2)+ "." + 
+  ("00" + d.getMilliseconds()).slice(-3);
+}
+
+Transform.mixin(FormatTime);
+
+FormatTime.prototype.write = function(name, level, args) {
+  var colors = { debug: 'blue', info: 'cyan', warn: 'yellow', error: 'red' };
+  this.emit('item', style(timestamp() +' ', 'grey')
+            + (name ? style(name +' ', 'grey') : '')
+            + (level ? style(level, colors[level]) + ' ' : '')
+            + args.map(function(item) {
+              return (typeof item == 'string' ? item : util.inspect(item, null, 3, true));
+            }).join(' '));
+};
+
+module.exports = FormatTime;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "minilog",
   "description": "Lightweight client & server-side logging with Stream-API backends and counting, timing support",
   "license": "MIT",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "lib/index.js",
   "dependencies": {
     "microee": "0.0.2"


### PR DESCRIPTION
Looks like this (forgive the cloud9 color scheme):  

![image](https://cloud.githubusercontent.com/assets/702031/14877930/ded43ad8-0ce5-11e6-81c2-ae76e9495598.png)

Basically the minilog.js format with a timestamp prepended to it.  Took the timestamp code from here (lorem monkey answer):

http://stackoverflow.com/a/30272803/1354111

No worries if you don't want to merge, but can you provide an example on how to apply the format from outside of your package environment?

Thanks, taji

