### PR TITLE
Fix inability to blacklist ‘error’ level messages

### DIFF
--- a/lib/common/filter.js
+++ b/lib/common/filter.js
@@ -40,7 +40,7 @@ Filter.prototype.test = function(name, level) {
     if(this._white[i] && test(this._white[i], name) && levelMap[level] >= this._white[i].l) {
       return true;
     }
-    if(this._black[i] && test(this._black[i], name) && levelMap[level] < this._black[i].l) {
+    if(this._black[i] && test(this._black[i], name) && levelMap[level] <= this._black[i].l) {
       return false;
     }
   }


### PR DESCRIPTION
Hi @mixu,

First off, thanks for this amazing library!

While testing black listing I realized there is no way to set the `defaultResult` to `true` and then `deny` error level messages of a given namespace.

One instinctively tries:
```javascript 
minilog.suggest.defaultResult = true;
minilog.suggest.deny('search', 'error');
```

However, this will only suppress logs less than `error`, not `error` itself. Since, there is no level above `error` it cannot currently be done.

After browsing the code I noticed that besides not being the expected behavior, it also wasn't the intended behavior.   :)

```javascript
// deny all matching, with level <= given level
```

So a simple typo change of `<` to `<=` was all that was needed for a fix. I also updated the filter testing to illustrate the issue.

Thanks again, cheers!

- Note: Some of the docs on your [website](http://mixu.net/minilog/filter.html) would need to be updated to reflect the change.