### PR TITLE
Fixed formatColor for node.js

### DIFF
--- a/lib/node/formatters/color.js
+++ b/lib/node/formatters/color.js
@@ -1,5 +1,6 @@
 var Transform = require('../../common/transform.js'),
-    style = require('./util.js').style;
+    style = require('./util.js').style,
+    util = require('util');
 
 function FormatColor() {}
 
@@ -10,7 +11,9 @@ FormatColor.prototype.write = function(name, level, args) {
   function pad(s) { return (s.toString().length == 4? ' '+s : s); }
   this.emit('item', (name ? name + ' ' : '')
           + (level ? style('- ' + pad(level.toUpperCase()) + ' -', colors[level]) + ' ' : '')
-          + args.join(' '));
+          + args.map(function(item) {
+            return (typeof item == 'string' ? item : util.inspect(item, null, 3, true));
+          }).join(' '));
 };
 
 module.exports = FormatColor;


### PR DESCRIPTION
formatColor printed `[object Object]`, unlike other formatters.
