### PR TITLE
Octal literal in strict mode: octal literals not allowed in strict mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	--include ./lib/web \
 	--exclude package.json \
 	$(DEFAULTS) \
-	--command 'uglifyjs --no-copyright --mangle-toplevel'
+	--command 'uglifyjs --toplevel'
 
 build-debug:
 	@mkdir -p ./dist/

--- a/lib/node/formatters/npm.js
+++ b/lib/node/formatters/npm.js
@@ -6,12 +6,12 @@ Transform.mixin(FormatNpm);
 
 FormatNpm.prototype.write = function(name, level, args) {
   var out = {
-        debug: '\033[34;40m' + 'debug' + '\033[39m ',
-        info: '\033[32m' + 'info'  + '\033[39m  ',
-        warn: '\033[30;41m' + 'WARN' + '\033[0m  ',
-        error: '\033[31;40m' + 'ERR!' + '\033[0m  '
+        debug: '\x1B[34;40m' + 'debug' + '\x1B[39m ',
+        info: '\x1B[32m' + 'info'  + '\x1B[39m  ',
+        warn: '\x1B[30;41m' + 'WARN' + '\x1B[0m  ',
+        error: '\x1B[31;40m' + 'ERR!' + '\x1B[0m  '
       };
-  this.emit('item', (name ? '\033[37;40m'+ name +'\033[0m ' : '')
+  this.emit('item', (name ? '\x1B[37;40m'+ name +'\x1B[0m ' : '')
           + (level && out[level]? out[level] : '')
           + args.join(' '));
 };

--- a/lib/node/formatters/util.js
+++ b/lib/node/formatters/util.js
@@ -1,20 +1,20 @@
 var styles = {
     //styles
-    'bold'      : ['\033[1m',  '\033[22m'],
-    'italic'    : ['\033[3m',  '\033[23m'],
-    'underline' : ['\033[4m',  '\033[24m'],
-    'inverse'   : ['\033[7m',  '\033[27m'],
+    'bold'      : ['\x1B[1m',  '\x1B[22m'],
+    'italic'    : ['\x1B[3m',  '\x1B[23m'],
+    'underline' : ['\x1B[4m',  '\x1B[24m'],
+    'inverse'   : ['\x1B[7m',  '\x1B[27m'],
     //grayscale
-    'white'     : ['\033[37m', '\033[39m'],
-    'grey'      : ['\033[90m', '\033[39m'],
-    'black'     : ['\033[30m', '\033[39m'],
+    'white'     : ['\x1B[37m', '\x1B[39m'],
+    'grey'      : ['\x1B[90m', '\x1B[39m'],
+    'black'     : ['\x1B[30m', '\x1B[39m'],
     //colors
-    'blue'      : ['\033[34m', '\033[39m'],
-    'cyan'      : ['\033[36m', '\033[39m'],
-    'green'     : ['\033[32m', '\033[39m'],
-    'magenta'   : ['\033[35m', '\033[39m'],
-    'red'       : ['\033[31m', '\033[39m'],
-    'yellow'    : ['\033[33m', '\033[39m']
+    'blue'      : ['\x1B[34m', '\x1B[39m'],
+    'cyan'      : ['\x1B[36m', '\x1B[39m'],
+    'green'     : ['\x1B[32m', '\x1B[39m'],
+    'magenta'   : ['\x1B[35m', '\x1B[39m'],
+    'red'       : ['\x1B[31m', '\x1B[39m'],
+    'yellow'    : ['\x1B[33m', '\x1B[39m']
   };
 
 exports.levelMap = { debug: 1, info: 2, warn: 3, error: 4 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,401 @@
+{
+  "name": "minilog",
+  "version": "3.1.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "acorn": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+      "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+      "dev": true
+    },
+    "amd-resolve": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/amd-resolve/-/amd-resolve-0.1.1.tgz",
+      "integrity": "sha1-WnEBy+zgeCibJNo5mcHdvWmDllQ=",
+      "dev": true
+    },
+    "amdetective": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/amdetective/-/amdetective-0.0.1.tgz",
+      "integrity": "sha1-0/Wvkx9BVtQ5AiElTAqaFquWHYs=",
+      "dev": true,
+      "requires": {
+        "esprima": "~1.0.4"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-resolve": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.2.4.tgz",
+      "integrity": "sha1-Wa54IKgpVezTL1+3xGisIcRyOAY=",
+      "dev": true,
+      "requires": {
+        "resolve": "0.6.3"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "dev": true
+    },
+    "bytes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
+      "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "debuglog": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-0.0.2.tgz",
+      "integrity": "sha1-bA3PB+LD90UkYpt0Fmi9RsezYus=",
+      "dev": true,
+      "optional": true
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "detective": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
+      "integrity": "sha1-d2l+LnlHrD/nyOJqbW8RUjWvqRw=",
+      "dev": true,
+      "requires": {
+        "acorn": "^3.1.0",
+        "defined": "^1.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+      "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "gluejs": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/gluejs/-/gluejs-2.4.0.tgz",
+      "integrity": "sha1-sW5yTHufXEXbtfuLov1aU3uM8vA=",
+      "dev": true,
+      "requires": {
+        "amd-resolve": "~0.1.1",
+        "amdetective": "0.0.1",
+        "browser-resolve": "~1.2.2",
+        "bytes": "~2.2.0",
+        "detective": "~4.3.1",
+        "minilog": "~2.1.0",
+        "minimatch": "~0.2.12",
+        "minitask": "~0.2.0",
+        "optimist": "~0.6.1",
+        "progress": "~1.1.2",
+        "readable-stream": "1.1.9",
+        "resolve": "~0.6.1"
+      }
+    },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "microee": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.6.tgz",
+      "integrity": "sha1-oSvbAQNoHosSapsHHrpMRnx4//4="
+    },
+    "minilog": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/minilog/-/minilog-2.1.0.tgz",
+      "integrity": "sha1-zHyAcKDMabdtLqoNtUaQLFzyIkU=",
+      "dev": true,
+      "requires": {
+        "microee": "0.0.2"
+      },
+      "dependencies": {
+        "microee": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/microee/-/microee-0.0.2.tgz",
+          "integrity": "sha1-cugNR3B15eeZRw9d7+qW0d0SFYc=",
+          "dev": true
+        }
+      }
+    },
+    "minimatch": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+      "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "miniq": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/miniq/-/miniq-0.1.2.tgz",
+      "integrity": "sha1-TUe+PiJtpvDrODtNmAUXu8pKhC8=",
+      "dev": true,
+      "requires": {
+        "microee": "~0.0.5"
+      }
+    },
+    "minitask": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/minitask/-/minitask-0.2.3.tgz",
+      "integrity": "sha1-rCN/B52O35NhmFR69oSd9T/TkDM=",
+      "dev": true,
+      "requires": {
+        "miniq": "~0.1.1",
+        "mkdirp": "~0.5.0"
+      }
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.1",
+        "commander": "2.15.1",
+        "debug": "3.1.0",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.5",
+        "he": "1.1.1",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.9.tgz",
+      "integrity": "sha1-2HEw+/j57pw7QFizxYo+MNsvz90=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "debuglog": "0.0.2"
+      }
+    },
+    "resolve": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
+      "integrity": "sha1-3ZV5gufnNt699TtYpN2RdUV13UY=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "minilog",
   "description": "Lightweight client & server-side logging with Stream-API backends and counting, timing support",
   "license": "MIT",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "main": "lib/index.js",
   "dependencies": {
     "microee": "0.0.6"


### PR DESCRIPTION
When minilog is used in a project that builds with something like rollup.js, when strict mode is enabled, octal literals (bare or in strings) are not allowed. 

This patch uses the alternate way, hex literals in strings. I.e. \033 -> \x1B